### PR TITLE
docs: document the full tool set in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ For available Moodle API functions, please refer to the [official documentation]
 
 1. Create your own `.env` file from `.env.example`
 2. Assume you have `uv` installed, run `uv add "mcp[cli]"` to install the MCP CLI tools
-3. Run `mcp install src/moodle_mcp/server.py -f .env` to add the moodle-mcp server to Claude app
+3. Run `mcp install main.py -f .env` to add the moodle-mcp server to Claude app
 
 ### Method 2: Using `uvx`
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,54 @@
 # Moodle-MCP
 
 > A Model Context Protocol (MCP) server implementation that provides capabilities to interact with Moodle LMS.
->
-> **Warning:** This project is still in development, only some functions are available.
 
 ## Features
 
-- [x] Get upcoming events from Moodle
+The server exposes the following tools.
+
+### Courses & content
+
+| Tool | Description |
+| --- | --- |
+| `get_my_courses` | Get all courses the current user is enrolled in |
+| `get_course_content` | Get sections and modules for a specific course by its ID |
+| `search_course_materials` | Search across all course materials by query string |
+| `get_course_announcements` | Get announcements from course news forums, optionally filtered by course ID |
+| `get_recent_activity` | Get recent activity and updates across courses since a given time |
+
+### Assignments & deadlines
+
+| Tool | Description |
+| --- | --- |
+| `get_assignments` | Get assignments for courses, optionally filtered by course IDs |
+| `get_assignment_status` | Get submission and grading status for a specific assignment |
+| `get_upcoming_deadlines` | Get upcoming assignment deadlines across all courses, sorted by due date |
+| `get_overdue_assignments` | Get unsubmitted assignments past their due date, most overdue first |
+| `get_actionable_tasks` | Get a prioritized list of tasks needing action, sorted by urgency |
+| `analyze_assignment` | Analyze an assignment: status, requirements, materials, progress, deadline |
+| `extract_assignment_requirements` | Extract requirements, deliverables, constraints, and evaluation criteria from an assignment |
+| `find_relevant_materials` | Find course content relevant to an assignment, ranked by relevance |
+| `decompose_task` | Break an assignment into subtasks with effort, dependencies, and critical path |
+| `create_implementation_plan` | Build a step-by-step plan with timeline, resources, milestones, and risks |
+
+### Grades & progress
+
+| Tool | Description |
+| --- | --- |
+| `get_grades` | Get a grade overview for all courses, or detailed grades for one course |
+| `get_course_progress` | Get progress and completion for one course or all courses |
+| `get_course_health` | Health check for a course: progress, grades, unsubmitted and overdue counts |
+| `get_study_load` | Analyze assignment distribution by week to identify heavy weeks |
+
+### Aggregated overviews
+
+| Tool | Description |
+| --- | --- |
+| `get_upcoming_events` | Get upcoming events from Moodle |
+| `semester_dashboard` | Combined overview of courses, upcoming deadlines, and grades |
+| `daily_briefing` | Daily summary of overdue count, today's deadlines, recent grades, events, and tasks |
+| `weekly_review` | Weekly summary of submitted/graded counts, deadlines, overdue count, and progress |
+| `ask_moodle` | Ask a natural language question and have it routed to the right data sources |
 
 ## API Reference
 
@@ -20,7 +62,7 @@ For available Moodle API functions, please refer to the [official documentation]
 
 1. Create your own `.env` file from `.env.example`
 2. Assume you have `uv` installed, run `uv add "mcp[cli]"` to install the MCP CLI tools
-3. Run `mcp install main.py -f .env` to add the moodle-mcp server to Claude app
+3. Run `mcp install src/moodle_mcp/server.py -f .env` to add the moodle-mcp server to Claude app
 
 ### Method 2: Using `uvx`
 


### PR DESCRIPTION
The README still advertised only `get_upcoming_events`, but `main` already ships around 24 tools after #4 merged. Anyone reading it would have no idea the server can list courses, pull assignments and deadlines, report grades and progress, or produce aggregated overviews like `daily_briefing` and `semester_dashboard`.

This rewrites the Features section into a grouped table that covers every tool currently registered in `src/moodle_mcp/server.py`, with a one-line description for each, and drops the stale in-development warning. It also fixes the Method 1 setup step, which pointed at `mcp install main.py`; the package now lives under `src/moodle_mcp/`, so the correct path is `mcp install src/moodle_mcp/server.py`. No code, version, or packaging changes.

Addresses the README portion of #5.