### PR TITLE
fix: correct glom delete paths so get_course_content works

### DIFF
--- a/src/moodle_mcp/moodle.py
+++ b/src/moodle_mcp/moodle.py
@@ -50,23 +50,23 @@ DELETE_FIELDS = {
         "events.*.course.courseimage"
     ],
     APIFunction.core_course_get_contents: [
-        "modules.*.modicon",
-        "modules.*.modplural",
-        "modules.*.onclick",
-        "modules.*.afterlink",
-        "modules.*.customdata",
-        "modules.*.contents.*.filepath",
-        "modules.*.contents.*.timecreated",
-        "modules.*.contents.*.timemodified",
-        "modules.*.contents.*.sortorder",
-        "modules.*.contents.*.isexternalfile",
-        "modules.*.contents.*.repositorytype",
-        "modules.*.contents.*.userid",
-        "modules.*.contents.*.author",
-        "modules.*.contents.*.license",
-        "modules.*.contents.*.mimetype",
-        "modules.*.completiondata",
-        "modules.*.contentsinfo",
+        "*.modules.*.modicon",
+        "*.modules.*.modplural",
+        "*.modules.*.onclick",
+        "*.modules.*.afterlink",
+        "*.modules.*.customdata",
+        "*.modules.*.contents.*.filepath",
+        "*.modules.*.contents.*.timecreated",
+        "*.modules.*.contents.*.timemodified",
+        "*.modules.*.contents.*.sortorder",
+        "*.modules.*.contents.*.isexternalfile",
+        "*.modules.*.contents.*.repositorytype",
+        "*.modules.*.contents.*.userid",
+        "*.modules.*.contents.*.author",
+        "*.modules.*.contents.*.license",
+        "*.modules.*.contents.*.mimetype",
+        "*.modules.*.completiondata",
+        "*.modules.*.contentsinfo",
     ],
     APIFunction.mod_assign_get_submission_status: [
         "lastattempt.submission.plugins",
@@ -132,6 +132,6 @@ def get_moodle_api_data(
         return data
 
     for field_path in DELETE_FIELDS.get(function, []):
-        delete(data, field_path)
+        delete(data, field_path, ignore_missing=True)
 
     return data


### PR DESCRIPTION
Closes #7

`get_course_content` always crashed with a glom `PathAccessError`, so the tool never returned anything. The `DELETE_FIELDS` cleanup for `core_course_get_contents` used paths starting at `modules.*`, but that web service returns a top-level array of sections. In Moodle core `get_course_contents_returns()` is an `external_multiple_structure`: https://github.com/moodle/moodle/blob/v4.5.9/course/externallib.php#L440-L443. The paths now start at `*.modules.*` so they iterate the section list first.

Several of those fields are also `VALUE_OPTIONAL` in Moodle and missing on many modules (forum and assign have no `contents`, and `completiondata`, `contentsinfo` and `repositorytype` are absent on some items), which made `glom.delete` raise `PathDeleteError` on the wildcard branches, so the delete now passes `ignore_missing=True`.

Verified against real course content: all 17 cleanup paths apply cleanly and the function returns the parsed sections.
