### PR TITLE
fix: make search_course_materials work without global search

### DIFF
--- a/src/moodle_mcp/api.py
+++ b/src/moodle_mcp/api.py
@@ -641,28 +641,46 @@ def _get_course_grades_detail(courseid: int) -> list[GradeItem]:
 
 
 def search_course_materials(query: str) -> list[SearchResult]:
-    data = get_moodle_api_data(
-        APIFunction.core_search_search,
-        params={"query": query},
-    )
+    """Search the user's course materials for a query string.
 
-    to_json_file(data, f"search_{query}.json")
+    Moodle global search (core_search_*) is an optional subsystem that is
+    disabled by default and needs a configured search engine, so it cannot be
+    relied on. Instead we search client-side over the contents of the enrolled
+    courses, matching section names, activity names and file names. This works
+    on any Moodle instance.
+    """
+    needle = query.lower().strip()
+    results: list[SearchResult] = []
 
-    results_raw = data.get("results", [])
+    for course in get_my_courses():
+        try:
+            sections = get_course_content(course["id"])
+        except MoodleAPIError as e:
+            logger.warning(f"Skipping course {course['id']} in search: {e}")
+            continue
 
-    result: list[SearchResult] = []
-    for item in results_raw:
-        result.append(
-            {
-                "title": item.get("title", ""),
-                "url": item.get("url", ""),
-                "content": item.get("content", ""),
-                "course_name": item.get("coursefullname", None),
-            }
-        )
+        for section in sections:
+            section_name = section.get("name") or ""
+            for module in section.get("modules", []):
+                name = module.get("name") or ""
+                filenames = [
+                    c.get("filename", "")
+                    for c in (module.get("contents") or [])
+                    if isinstance(c, dict)
+                ]
+                haystack = " ".join([name, section_name, *filenames]).lower()
+                if needle and needle in haystack:
+                    results.append(
+                        {
+                            "title": name,
+                            "url": module.get("url") or "",
+                            "content": section_name,
+                            "course_name": course.get("fullname"),
+                        }
+                    )
 
-    logger.info(f"Search for '{query}' returned {len(result)} results")
-    return result
+    logger.info(f"Search for '{query}' matched {len(results)} materials")
+    return results
 
 
 # ---------------------------------------------------------------------------

--- a/src/moodle_mcp/moodle.py
+++ b/src/moodle_mcp/moodle.py
@@ -33,7 +33,6 @@ class APIFunction(Enum):
         "gradereport_overview_get_course_grades"
     )
     gradereport_user_get_grade_items = "gradereport_user_get_grade_items"
-    core_search_search = "core_search_search"
     core_course_get_updates_since = "core_course_get_updates_since"
     mod_forum_get_forums_by_courses = "mod_forum_get_forums_by_courses"
     mod_forum_get_discussions = "mod_forum_get_discussions"


### PR DESCRIPTION
Closes #8

`search_course_materials` called `APIFunction.core_search_search`, which is not a real Moodle web service function, so every call failed with `invalidrecord`. The real global search functions are `core_search_*` (https://github.com/moodle/moodle/blob/v4.5.9/lib/db/services.php#L1784-L1812), but global search is an optional subsystem that is off by default (https://github.com/moodle/moodle/blob/v4.5.9/admin/settings/subsystems.php#L44-L45) and needs a search engine plus indexing, so it cannot be relied on across instances.

This rewrites the tool to search client side over the user's enrolled courses, reusing `get_my_courses` and `get_course_content` and matching the query against section names, activity names and file names. It now works on any Moodle regardless of the global search configuration. The unused `core_search_search` enum entry is removed.

Verified against a live Moodle: queries return matching materials instead of an `invalidrecord` error.
